### PR TITLE
Updating elim.css for better reporting

### DIFF
--- a/elim.css/README.md
+++ b/elim.css/README.md
@@ -14,19 +14,32 @@ The context switches ELIM can be used for the following purposes:
 
 For example, you can do the following:
 
-	bsub -R "order[css]" ./a.out
+	bsub -R "order[cssMin]" ./a.out
 
 Which would dispatch to the host with the lowest number of context switches.  Additionally, you could do the following:
 
-	bsub -R "select[css<1000]" ./a.out
+	bsub -R "select[cssAvg<1000]" ./a.out
 
-The bsub above would only select hosts that have an css of less than 1000 context switches per second to dispatch to.
+The bsub above would only select hosts that have an average css of less than 1000 context switches per second to dispatch to.
 
 ## Installation Instructions
 
-To install this ELIM, you must first add the "css" numeric resource to LSF as per the normal process which involves updating your lsf.shared and lsf.cluster files to include the value.  Ensure that you assign this resource to hosts your UNIX/Linux hosts.
+To install this ELIM, you must first add the the numeric resource to LSF as per the normal process which involves updating your lsf.shared and lsf.cluster files to include the values.  Ensure that you assign this resource to hosts your UNIX/Linux hosts.
 
-Then, before restarting the cluster, make sure that the elim.css binary has been copied to the $LSF_SERVERDIR for all compute hosts and marked executable.  After which, you can restart your cluster using:
+The numeric resources to add are shown in the example lsf.shared file and lsf.cluster example files included in this repo.  They include:
+
+cssMin = The minumum context switches per second in the reporting period
+cssMax = The maximum context switches per second in the reporting period
+cssAvg = The average context switches per second in the reporting period
+
+Then, before restarting the cluster, make sure that the elim.css binary has been copied to the $LSF_SERVERDIR for all compute hosts and marked executable.  Additionally, there are two variables in the elim.css that can be modified that affect the granularity of the data.  They are:
+
+sleep_time = 2 seconds, the time between checks of the data
+report_time = 60 seconds, the time between reporting min, max, and average data to LSF
+
+If you change either of these settings, make sure that you update the lsf.shared file to reflect the new report_time setting.
+
+After which, you can restart your cluster using:
 
 	lsadmin reconfig
 	badmin reconfig
@@ -35,7 +48,7 @@ Make sure you restart all LIM's and not just the Master LIM.  From each compute 
 
 You can also get the context switches per second of your hosts by running the following lsload command:
 
-	lsload -o "css"
+	lsload -o "cssAvg cssMin cssMax" -json
 
 ## Community Contribution Requirements
 

--- a/elim.css/README.md
+++ b/elim.css/README.md
@@ -2,7 +2,9 @@
 
 ## Description
 
-The ELIM included in this directory reports an hosts context switches per second to LSF.  This data can be used visually track host context switches in LSF RTM via it's ELIM Template graphs.  
+The ELIM included in this directory reports an hosts context switches per 
+second to LSF.  This data can be used visually track host context 
+switches in LSF RTM via it's ELIM Template graphs.  
 
 ## Use Cases
 
@@ -10,49 +12,64 @@ The context switches ELIM can be used for the following purposes:
 
 1) Reporting in tools like RTM using ELIM Templates
 
-2) Sorting of devices to be used for dispatch, or to select hosts with a specific number of context switches per second range.  
+2) Sorting of devices to be used for dispatch, or to select hosts with a 
+   specific number of context switches per second range.  
 
 For example, you can do the following:
 
 	bsub -R "order[cssMin]" ./a.out
 
-Which would dispatch to the host with the lowest number of context switches.  Additionally, you could do the following:
+Which would dispatch to the host with the lowest number of context switches.  
+Additionally, you could do the following:
 
 	bsub -R "select[cssAvg<1000]" ./a.out
 
-The bsub above would only select hosts that have an average css of less than 1000 context switches per second to dispatch to.
+The bsub above would only select hosts that have an average css of less than 
+1000 context switches per second to dispatch to.
 
 ## Installation Instructions
 
-To install this ELIM, you must first add the the numeric resource to LSF as per the normal process which involves updating your lsf.shared and lsf.cluster files to include the values.  Ensure that you assign this resource to hosts your UNIX/Linux hosts.
+To install this ELIM, you must first add the the numeric resource to LSF as per 
+the normal process which involves updating your lsf.shared and lsf.cluster files 
+to include the values.  Ensure that you assign this resource to hosts your 
+UNIX/Linux hosts.
 
-The numeric resources to add are shown in the example lsf.shared file and lsf.cluster example files included in this repo.  They include:
+The numeric resources to add are shown in the example lsf.shared file and 
+lsf.cluster example files included in this repo.  They include:
 
 cssMin = The minumum context switches per second in the reporting period
 cssMax = The maximum context switches per second in the reporting period
 cssAvg = The average context switches per second in the reporting period
 
-Then, before restarting the cluster, make sure that the elim.css binary has been copied to the $LSF_SERVERDIR for all compute hosts and marked executable.  Additionally, there are two variables in the elim.css that can be modified that affect the granularity of the data.  They are:
+Then, before restarting the cluster, make sure that the elim.css binary has been 
+copied to the $LSF_SERVERDIR for all compute hosts and marked executable.  
+Additionally, there are two variables in the elim.css that can be modified that 
+affect the granularity of the data.  They are:
 
 sleep_time = 2 seconds, the time between checks of the data
 report_time = 60 seconds, the time between reporting min, max, and average data to LSF
 
-If you change either of these settings, make sure that you update the lsf.shared file to reflect the new report_time setting.
+If you change either of these settings, make sure that you update the lsf.shared 
+file to reflect the new report_time setting.
 
 After which, you can restart your cluster using:
 
 	lsadmin reconfig
 	badmin reconfig
 
-Make sure you restart all LIM's and not just the Master LIM.  From each compute host, you should then see the binary running in the background.  If not, you should debug the binary interactively using simply by running from the command line on your hosts.
+Make sure you restart all LIM's and not just the Master LIM.  From each compute host, 
+you should then see the binary running in the background.  If not, you should debug 
+the binary interactively using simply by running from the command line on your hosts.
 
-You can also get the context switches per second of your hosts by running the following lsload command:
+You can also get the context switches per second of your hosts by running the 
+following lsload command:
 
 	lsload -o "cssAvg cssMin cssMax" -json
 
 ## Community Contribution Requirements
 
-Community contributions to this repository must follow the [IBM Developer's Certificate of Origin (DCO)](https://github.com/IBMSpectrumComputing/platform-python-lsf-api/blob/master/IBMDCO.md) process and only through GitHub Pull Requests:
+Community contributions to this repository must follow the [IBM Developer's Certificate of Origin (DCO)](https://github.com/IBMSpectrumComputing/platform-python-lsf-api/blob/master/IBMDCO.md) 
+process and only through GitHub Pull Requests:
 
  1. Contributor proposes new code to community.
 
@@ -65,7 +82,8 @@ Community contributions to this repository must follow the [IBM Developer's Cert
     i)  Applicability and relevancy of functional content 
     ii) Any obvious issues
 
- 4. If accepted, posts contribution. If rejected, work goes back to contributor and is not merged.
+ 4. If accepted, posts contribution. If rejected, work goes back to contributor 
+    and is not merged.
 
 ## Copyright
 

--- a/elim.css/elim.css
+++ b/elim.css/elim.css
@@ -7,28 +7,75 @@
 #          scheduling thresholds.
 #
 # Author:  Larry Adams <adamsla@us.ibm.com>
+#          Larry Adams <thewitness@cacti.net>
 #
 # --------------------------------------------------------------------------
 
 # --------------------------------------------------------------------------
-# Change the one variable below to match lsf.shared
+# This elim will track context switches per second and report out every
+# few seconds the max, min, and average context switches per second.
+# This data is mostly to be used for tracking hosts that are overloaded
+# which can cause JITTER inside of an HPC cluster.  RTM can be used then
+# to review the jobs generating the JITTER for corrective action.  Corrective
+# actions can include: Requesting more CPUs, Requesting more memory,
+# Requesting exclusive use of the host using various methods.
 # --------------------------------------------------------------------------
-sleep=60
 
-last_css=
+# --------------------------------------------------------------------------
+# Modify these two values to match your requirements. Ensure that
+# the report_time is exually divisible by the sleep_time.
+# --------------------------------------------------------------------------
+sleep_time=2
+report_time=60
+
+# --------------------------------------------------------------------------
+# If debugging uncomment the following line
+# --------------------------------------------------------------------------
+# set -x
+
+# --------------------------------------------------------------------------
+# Keep everything below this line fixed.
+# --------------------------------------------------------------------------
+
+report_loops=$(($report_time/$sleep_time))
+last_css=-1
+init_css=-1
+avg_css=0
+min_css=-1
+max_css=0
+cur_loops=0
 
 while true;do
-  if [ -z "$last_css" ]; then
-    last_css=`grep ctxt /proc/stat | awk '{print $2}'`
+  css=$(grep ctxt /proc/stat | awk '{print $2}')
+  if [ $last_css -eq -1 ]; then
+	init_css=$css
+    #echo "3 cssMin 0 cssMax 0 cssAvg 0"
     echo "0 "
   else
-    css=`grep ctxt /proc/stat | awk '{print $2}'`
     diffcss=$(($css-$last_css))
-    out_css=$(($diffcss/$sleep))
-    last_css=$css
-    echo "1 css $out_css"
+    cur_css=$(($diffcss/$sleep_time))
+
+    if [ $cur_loops == $report_loops ]; then
+      avg_css=$((($css-$init_css)/$report_time))
+      echo "3 cssMin $min_css cssMax $max_css cssAvg $avg_css"
+      min_css=-1
+      max_css=0
+      avg_css=0
+      cur_loops=0
+	  init_css=$css
+    else
+      if [ $cur_css -gt $max_css ]; then
+        max_css=$cur_css
+      elif [ $cur_css -lt $min_css -o $min_css -eq -1 ]; then
+        min_css=$cur_css
+      fi
+
+      cur_loops=$(($cur_loops+1))
+    fi
   fi
 
-  sleep $sleep
+  last_css=$css
+
+  sleep $sleep_time
 done
 

--- a/elim.css/lsf.cluster
+++ b/elim.css/lsf.cluster
@@ -1,0 +1,6 @@
+Begin ResourceMap
+RESOURCENAME  LOCATION
+cssAvg        [default]
+cssMin        [default]
+cssMax        [default]
+End ResourceMap

--- a/elim.css/lsf.shared
+++ b/elim.css/lsf.shared
@@ -1,0 +1,7 @@
+Begin Resource
+RESOURCENAME  TYPE     INTERVAL INCREASING CONSUMABLE DESCRIPTION
+cssMin        Numeric  60       Y          ()         (Minimum Context Switches per Second)
+cssMax        Numeric  60       Y          ()         (Maximum Context Switches per Second)
+cssAvg        Numeric  60       Y          ()         (Average Context Switches per Second)
+End Resource
+


### PR DESCRIPTION
This enhanced elim provides more granular reporting including renaming the reporting variables to:

cssMin - Minimum Context Switches Per Second
cssMax - Maximum Context Switches Per Second
cssAvg - Average Context Switches Per Second

These elim values can be used for making dispatch decisions and for performing fault management in tools such as RTM.

Signed-Off: thewitness@cacti.net